### PR TITLE
Some typos and whitespace removal

### DIFF
--- a/dsglaser/cis_security/README.md
+++ b/dsglaser/cis_security/README.md
@@ -96,7 +96,7 @@ run, you must exclude both tags:
 ```
 ansible-playbook -i <inventory> <playbook.yml> --skip-tags "6.1.2,6.1.4"
 ```
-Some controls are surrouned by Ansible blocks that themselves have tags. Excluding the tag that applies
+Some controls are surrounded by Ansible blocks that themselves have tags. Excluding the tag that applies
 to the block will exclude all of the tasks inside of the block. If the block's tag is **not** excluded,
 then individual tasks inside of the block can be excluded by excluding their tags.
 

--- a/dsglaser/cis_security/README.md
+++ b/dsglaser/cis_security/README.md
@@ -100,7 +100,7 @@ Some controls are surrounded by Ansible blocks that themselves have tags. Exclud
 to the block will exclude all of the tasks inside of the block. If the block's tag is **not** excluded,
 then individual tasks inside of the block can be excluded by excluding their tags.
 
-The list of tags and their associated crontol descriptions are listed in the [controls_list](./docs/controls_list.md) file for Linux and [control_list_win](./docs/controls_list_win.md_ file for Windows)
+The list of tags and their associated control descriptions are listed in the [controls_list](./docs/controls_list.md) file for Linux and [control_list_win](./docs/controls_list_win.md_ file for Windows)
 in the docs directory.
 
 In addition to tags, there are a number of variables that can be set which will enable or disable

--- a/dsglaser/cis_security/roles/cis_security/handlers/main.yml
+++ b/dsglaser/cis_security/roles/cis_security/handlers/main.yml
@@ -53,7 +53,7 @@
 
 - name: restart tmpfs
   systemd:
-    name: tmpfs.mount
+    name: tmp.mount
     state: restarted
     enabled: yes
     masked: no

--- a/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
+++ b/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
@@ -82,13 +82,7 @@
 
   # Create and configure the local-fs systemd service file
   - name: 1.1.[2-5] - Ensure /tmp is configured
-    block:
-      # Cloud images often have tmpfs.mount masked. Unmask it so it can be enabled.
-      - name: Ensure tmpfs.mount is not masked
-        systemd:
-          name: tmpfs.mount
-          masked: no
-          
+    block:       
       # Create a file to hold the system specific local-fs service information
       #  be sure to set the selinux security context. Even if selinux is disabled,
       #  it's a good idea to make sure it is set on files

--- a/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
+++ b/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
@@ -717,7 +717,7 @@
     tags:
       - 1.6.1
 
-  - name: 1.6.2 - Ensure address space layout reandomization (ASLR) is enabled
+  - name: 1.6.2 - Ensure address space layout randomization (ASLR) is enabled
       # The sysctl module will set variables in /etc/sysctl.conf and tell sysctl
       #  to reload them immediately if 'reload' is set to 'yes'.
     sysctl:

--- a/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
+++ b/dsglaser/cis_security/roles/cis_security/tasks/type-files/redhat-8-type.yml
@@ -83,6 +83,12 @@
   # Create and configure the local-fs systemd service file
   - name: 1.1.[2-5] - Ensure /tmp is configured
     block:
+      # Cloud images often have tmpfs.mount masked. Unmask it so it can be enabled.
+      - name: Ensure tmpfs.mount is not masked
+        systemd:
+          name: tmpfs.mount
+          masked: no
+          
       # Create a file to hold the system specific local-fs service information
       #  be sure to set the selinux security context. Even if selinux is disabled,
       #  it's a good idea to make sure it is set on files


### PR DESCRIPTION
I noticed some typos in the main README and in the redhat-8-type.yml. I've fixed them in my fork.
The GitHub editor also seems to have automatically eliminated some whitespace in the YAML file.