### PR TITLE
changes for ubuntu 18.04

### DIFF
--- a/dsglaser/cis_security/roles/cis_security/handlers/main.yml
+++ b/dsglaser/cis_security/roles/cis_security/handlers/main.yml
@@ -7,6 +7,7 @@
 - name: reload audit rules
   shell: /usr/sbin/augenrules --load
   listen: "restart auditd"
+  when: ansible_distribution != "Ubuntu"
 
 - name: restart audit service
   service:

--- a/dsglaser/cis_security/roles/cis_security/tasks/type-files/ubuntu-18-type.yml
+++ b/dsglaser/cis_security/roles/cis_security/tasks/type-files/ubuntu-18-type.yml
@@ -119,7 +119,18 @@
     block:
       # Create a file to hold the system specific local-fs service information
       #  be sure to set the selinux security context. Even if selinux is disabled,
-      #  it's a good idea to make sure it is set on files
+      #  it's a good idea to make sure it is set on files      
+      - name: 1.1.[2-5] - Configure config file for tmpfs
+        blockinfile:
+          path: /etc/systemd/system/tmp.mount
+          block: |
+            [Mount]
+            What=tmpfs
+            Where=/tmp
+            Type=tmpfs
+            Options=mode=1777,strictatime,noexec,nodev,nosuid
+          create: true
+
       - name: Ensure the local-fs directory is created
         file:
           path: /etc/systemd/system/local-fs.target.wants
@@ -129,19 +140,16 @@
           mode: 0755
           setype: etc_t
 
-      # Add content to the file we created using the blockinfile command.
-      # Notify systemd to reload its daemons and start the local-fs service
-      - name: 1.1.[2-5] - Configure config file for tmpfs
-        blockinfile:
-          path: /etc/systemd/system/local-fs.target.wants/tmp.mount
-          block: |
-            [Mount]
-            What=tmpfs
-            Where=/tmp
-            Type=tmpfs
-            Options=mode=1777,strictatime,noexec,nodev,nosuid
-          create: true
+      # symbolic link is required for .wants/ folder 
+      - name: Create a symbolic link      
+        ansible.builtin.file:
+          src: /etc/systemd/system/tmp.mount
+          dest: /etc/systemd/system/local-fs.target.wants/tmp.mount          
+          owner: root
+          group: root        
+          state: link
         notify: restart tmpfs
+
     tags:
       - 1.1.2
       - 1.1.3


### PR DESCRIPTION
on 1.1.2 the tmpfs mount 
the .wants/ folder requires symbolic links.

the following error message appears 

 systemd[1]: local-fs.target: Wants dependency dropin /etc/systemd/system/local-fs.target.wants/tmp.mount is not a symlink, ignoring.